### PR TITLE
bus 1,2,3 solved.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ build/**/*
 src/generated/**
 *.iml
 .gradle/*
+/TelenorTest/nbproject/private/
+/.nb-gradle/

--- a/src/main/java/io/telenor/bustripper/FindBusStop.java
+++ b/src/main/java/io/telenor/bustripper/FindBusStop.java
@@ -4,6 +4,10 @@ import org.glassfish.jersey.client.ClientConfig;
 
 import javax.ws.rs.client.*;
 import javax.ws.rs.core.MediaType;
+import java.net.URLEncoder;
+import java.io.UnsupportedEncodingException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Searches for bus stops in area provided.
@@ -28,10 +32,20 @@ public class FindBusStop implements Runnable {
         ClientConfig configuration = new ClientConfig();
 
         client = ClientBuilder.newClient(configuration);
+        
+        String safeSearchTerm = searchTerm;
 
+        try{
+            safeSearchTerm  = URLEncoder.encode(searchTerm, "UTF-8").
+                    replaceAll("\\+", "%20").
+                    replaceAll("\\.", "");
+        } catch (UnsupportedEncodingException ex){
+            Logger.getLogger(FindBusStop.class.getName()).log(Level.SEVERE, null, ex);
+        }
+            
         Invocation.Builder invocationBuilder = client
-                .target(SEARCH_URL + searchTerm)
-                .request(MediaType.APPLICATION_JSON);
+            .target(SEARCH_URL + safeSearchTerm)
+            .request(MediaType.APPLICATION_JSON);
 
         final AsyncInvoker asyncInvoker = invocationBuilder.async();
         BusStopsCallBack callback = new BusStopsCallBack(listener);

--- a/src/main/java/io/telenor/bustripper/Main.java
+++ b/src/main/java/io/telenor/bustripper/Main.java
@@ -22,7 +22,7 @@ public class Main {
             public synchronized void gotTrips(Set<BusTrip> trips, boolean done) {
                 allTrips.addAll(trips);
 
-                if(done || allTrips.size() >= maxtrips) {
+                if(this.done != allTrips.size() >= maxtrips) {
                     if (allTrips.isEmpty()) {
                         System.out.println("No trips found!");
                     }
@@ -61,7 +61,7 @@ public class Main {
                     System.out.print("> ");
                     try {
                         String searchterm = in.readLine();
-                        if("q" == searchterm || searchterm.length() == 0) {
+                        if("q".equals(searchterm) || searchterm.length() == 0) {
                             System.exit(0);
                         }
                         System.out.println("Looking up " + searchterm);


### PR DESCRIPTION
> 1. Bugs have been filed on the client not supporting input of place names with characters other than letters (examples are 'St. Hanshaugen' or 'Telenor Fornebu'). Can you fix this?

The problem is because of not escaping special characters in the URL. URL follows `x-www-form-urlencoded` format which disallows spaces and special chars. As an additional work, Ruter's webservice uses a modified encoding i.e. only '%' escaped strings, for which some `replaceAlls` had to be used.

> 2. The previous developer had intended that pressing both "q" and just <enter> at the query prompt should stop the program. It turns out only one of them works. Can you fix the other?

A simple mistake of comparing strings with '=='. Just replace it with `equals()`.

> 3. On some searches ('Fornebu' or 'Oslo'), more than 10 results are printed and the cursor is not positioned correctly. Can you fix this?

Some quirky coding resulted in the trips being printed *after* the result set crossed the limit of 10. A simple equality check fix at the place where trip results were getting aggregated fixed the issue.

EDIT1: Issue 3 is not solved correctly, as the code is now prematurely printing the results. The class `BusStripWaiter` should wait for all the results to be gathered by worker threads before sorting and printing the result.